### PR TITLE
Add "inventory" for v1.9

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,6 @@
 [defaults]
 hostfile = hosts
+inventory = hosts
+
+[ssh_connection]
+ssh_args = -o ForwardAgent=yes

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,3 @@
 [defaults]
 hostfile = hosts
 inventory = hosts
-
-[ssh_connection]
-ssh_args = -o ForwardAgent=yes


### PR DESCRIPTION
"hostfile" has been deprecated from v1.9, use "inventory" instead.
