### PR TITLE
Updated Vagrantfile to match code-env's DNS settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,5 +8,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "../data", "/home/vagrant/data", type: "nfs"
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 1024]
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end
 end

--- a/setup.yml
+++ b/setup.yml
@@ -217,9 +217,13 @@
       command: forever list
       register: forever_list
       changed_when: false
+      sudo: no
     - name: start API ver2.0 server
-      command: forever start /home/vagrant/data/Attache-node-api/server.js
-      when: "forever_list.stdout.find('/home/vagrant/data/Attache-node-api/server.js') == -1"
+      # the -w flag reloads the server when app files have changed
+      # the --uid flag lets us assign a unique ID to the daemon so we can find it later in "forever list"
+      command: forever -w --uid "attacheNodeServerID" start server.js chdir=data/Attache-node-api
+      when: "forever_list.stdout.find('attacheNodeServerID') == -1"
+      sudo: no
 
     - name: create mysql table
       mysql_db: name=attache state=import target=/home/vagrant/data/Attache/sql/create.sql

--- a/setup.yml
+++ b/setup.yml
@@ -61,7 +61,7 @@
     - name: Install git
       apt: name=git
     - name: copy private key
-      copy: src={{private_key_path}} dest=/home/vagrant/.ssh/id_rsa owner=vagrant group=vagrant mode=0600    
+      copy: src={{private_key_path}} dest=/home/vagrant/.ssh/id_rsa owner=vagrant group=vagrant mode=0600
 
     #############################################
     # Setup node.js(grunt, gulp, bower, forever)
@@ -203,6 +203,7 @@
       command: composer install chdir=data/Attache
     - name: npm install
       npm: path=/home/vagrant/data/Attache
+      sudo: no
     - name: grunt build
       command: grunt build --force chdir=data/Attache
       sudo: no
@@ -211,6 +212,7 @@
 
     - name: npm install (API ver2.0)
       npm: path=/home/vagrant/data/Attache-node-api
+      sudo: no
     - name: check list of Node.js apps running
       command: forever list
       register: forever_list


### PR DESCRIPTION
- See http://serverfault.com/questions/495914/vagrant-slow-internet-connection-in-guest
- npm install was having issues using chown, which prevented Grunt from being installed properly
- Setting 'sudo' to 'no' on the npm install tasks has resolved the issue
- Fixes #3 

I've also noticed that the npm tasks are running faster. I'm not sure if that's the DNS change or if NPM was just running slowly when I tested last week. We can keep an eye on it but for now things seem good.
